### PR TITLE
Require Jenkins 2.164.1, Confluence to GitHub move

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+_extends: .github
+tag-template: config-driven-pipeline-$NEXT_MINOR_VERSION

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Config-Driven Pipeline Plugin
 [![License](https://img.shields.io/github/license/jenkinsci/config-driven-pipeline-plugin.svg)](LICENSE)
-[![wiki](https://img.shields.io/badge/Config--Driven%20Pipeline%20Plugin-WIKI-blue.svg?style=flat)](https://plugins.jenkins.io/config-driven-pipeline)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/config-driven-pipeline.svg)](https://plugins.jenkins.io/config-driven-pipeline)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/config-driven-pipeline-plugin.svg?label=changelog)](https://github.com/jenkinsci/config-driven-pipeline-plugin/releases/latest)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/config-driven-pipeline.svg?color=blue)](https://plugins.jenkins.io/config-driven-pipeline)
 
 ## Purpose
 Would you like to share `Jenkinsfile` without copy-pasting in git (or other SCMs) but

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <name>Config-Driven Pipeline Plugin</name>
   <description>Uses a config file in the source repo to route to a Jenkinsfile in a centralized repo of Jenkinsfiles
     and provides the config content as a PIPELINE_CONFIG environment variable to hydrate the pipeline with data.</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Config-Driven+Pipeline+Plugin</url>
+  <url>https://github.com/jenkinsci/config-driven-pipeline-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>
@@ -52,7 +52,7 @@
     <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
     <java.level>8</java.level>
     <java.version>1.8</java.version>
-    <jenkins.version>2.107.3</jenkins.version>
+    <jenkins.version>2.164.1</jenkins.version>
     <junit.version>4.12</junit.version>
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
     <pipeline-utility-steps-test.version>2.0</pipeline-utility-steps-test.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <github-branch-source.version>2.4.1</github-branch-source.version>
     <groovy.eclipse.batch.version>2.4.3-01</groovy.eclipse.batch.version>
     <groovy.eclipse.compiler.version>2.9.2-01</groovy.eclipse.compiler.version>
-    <groovy.version>2.4.11</groovy.version>
+    <groovy.version>2.4.12</groovy.version>
     <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
     <java.level>8</java.level>
     <java.version>1.8</java.version>


### PR DESCRIPTION
Background: https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/

* Add to Release Drafter:
  https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
* Add new plugin info badges to README
* Change primary wiki to GitHub README in POM
* Bump Jenkins dependency to 2.164.1