### PR TITLE
Allow pipeline_template at end of file w/o newline

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/template/finder/ConfigurationValueFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/template/finder/ConfigurationValueFinder.java
@@ -30,14 +30,21 @@ public class ConfigurationValueFinder {
         if (indexOfKey == -1) {
             return null;
         }
-        int indexAfterKey = keyToFind.length() + indexOfKey;
-        int firstNewLine = configurationContents.indexOf("\n", indexAfterKey);
-        String delimiterAndValueString = configurationContents.substring(indexAfterKey, firstNewLine);
-        String valueWithoutDelimitersQuotesAndTicks = removeDelimitersQuotesAndTicks(delimiterAndValueString);
+        String delimiterAndValue = getDelimiterAndValue(configurationContents, keyToFind, indexOfKey);
+        String valueWithoutDelimitersQuotesAndTicks = removeDelimitersQuotesAndTicks(delimiterAndValue);
         if (valueWithoutDelimitersQuotesAndTicks == null) {
             return null;
         }
         return valueWithoutDelimitersQuotesAndTicks.trim();
+    }
+
+    private static String getDelimiterAndValue(String configurationContents, String keyToFind, int indexOfKey) {
+        int indexAfterKey = keyToFind.length() + indexOfKey;
+        int firstNewLine = configurationContents.indexOf("\n", indexAfterKey);
+        if (firstNewLine == -1) {
+            return configurationContents.substring(indexAfterKey);
+        }
+        return configurationContents.substring(indexAfterKey, firstNewLine);
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/template/finder/ConfigurationValueFinderTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/template/finder/ConfigurationValueFinderTest.groovy
@@ -17,12 +17,16 @@ class ConfigurationValueFinderTest extends Specification {
         where:
         firstValue | configKey       | configText
         null       | null            | "test"
+        "value"    | "nonewline"     | "nonewline:value"
         null       | "test1"         | null
         null       | "test1"         | "keynotfound"
         "hi"       | "bare"          | "bare:hi\n test1:second\n test1:third"
         "hi"       | "quotes"        | '"quotes":"hi"\n test1:second\n test1:third'
+        "third"    | "last"          | '"quotes":"hi"\n test1:second\n last:third'
         "hi"       | "equals_space"  | 'equals_space = "hi"\ntest1 = second\ntest2 = third'
+        "third"    | "last"          | 'equals_space = "hi"\ntest1 = second\nlast = third'
         "hi"       | "equals"        | 'equals="hi"\ntest1=second\ntest2=third'
+        "third"    | "last"          | 'equals="hi"\ntest1=second\nlast=third'
         "hi"       | "ticks"         | '\'ticks\':\'hi\'\n test1:second\n test1:third'
         "hi"       | "spaces"        | '\'spaces\' :          \'hi\'        \n test1:second\n test1:third'
 


### PR DESCRIPTION
A pipeline_template found with no new line after it will throw
StringIndexOutOfBounds (yowza).

Fixes #26