### PR TITLE
Bump to Jenkins 2.222.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <java.level>8</java.level>
     <java.version>1.8</java.version>
-    <jenkins.version>2.204.6</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <junit.version>4.13.1</junit.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <pipeline-utility-steps-test.version>2.0</pipeline-utility-steps-test.version>


### PR DESCRIPTION
Dependency org.jenkins-ci.plugins:jackson2-api:jar:2.12.1 requires Jenkins 2.222.4 or higher.